### PR TITLE
Add preliminary support for DD-WRT et al.

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,8 @@
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+-P ubuntu-22.04=catthehacker/ubuntu:act-22.04
+-P ubuntu-20.04=catthehacker/ubuntu:act-20.04
+-P ubuntu-18.04=catthehacker/ubuntu:act-18.04
+--var DOCKERHUB_USERNAME=thijsputman
+-s GITHUB_TOKEN
+-s DOCKERHUB_TOKEN
+--artifact-server-path .github/artifacts

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           semver=$(
             ./sysmon.sh --version | \
-            grep -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+'
+            grep -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[-a-z0-9\.]+)?'
           )
           echo semver="v$semver" >> "$GITHUB_OUTPUT"
       - name: Generate Docker metadata
@@ -33,9 +33,12 @@ jobs:
             type=semver,pattern={{version}},value=${{ steps.sysmon.outputs.semver }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.sysmon.outputs.semver }}
             type=semver,pattern={{major}},value=${{ steps.sysmon.outputs.semver }}
+            type=ref,event=pr,prefix=pr-
+            type=edge,branch=develop
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
           # yamllint enable rule:line-length
           flavor: |
-            latest=true
+            latest=false
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
       - name: Setup Docker buildx
@@ -46,7 +49,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /NOTES
+.github/artifacts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         types: [file]
         files: (?i)(\.md|(^|/)(TODO|NOTES))$
       - id: yamllint-other
-        name: yamllint (other)
+        name: yamllint
         entry: yamllint -s
         language: system
         types: [yaml]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A simple shell-script to capture a handful of common metrics and push them over
 MQTT to [Home Assistant](https://www.home-assistant.io/).
 
 This script has been tested on recent versions of various Linux distributions
-(Ubuntu, Raspberry Pi OS, Armbian and Alpine) on AMD64, ARM(64) and RISC-V based
-devices. Given its relative simplicity, it probably works on virtually any Linux
-device that allows installing a handful of (generic) dependencies.
+(Ubuntu, Raspberry Pi OS, Armbian, Alpine, and DD-WRT) on AMD64, ARM(64) and
+RISC-V based devices. Given its relative simplicity, it probably works on
+virtually any Linux device that allows installing a handful of (generic)
+dependencies.
 
 Until December 2023, this script was part of my
 [Home Assistant configuration](https://github.com/thijsputman/home-assistant-config/tree/2ec7d637e642196f45a04fa0f99c0eeee4daba9d/extras/sysmon-mqtt)-repository.
@@ -159,12 +160,19 @@ before continuing...
 
 ## Setup
 
-The script depends on `apt`, `bash`,
-**[`gawk`](https://www.gnu.org/software/gawk/manual/gawk.html)**, `iw`, `jq`,
-and `mosquitto-clients`.
+The script depends on `bash`,
+**[`gawk`](https://www.gnu.org/software/gawk/manual/gawk.html)** (alternative
+versions of `awk` are _not_ supported; you need
+[GNU `awk`](https://www.gnu.org/software/gawk/manual/gawk.html)), `jq`, and
+`mosquitto-clients`.
 
-**N.B.**, alternative versions of `awk` are _not_ supported; you need
-[GNU `awk`](https://www.gnu.org/software/gawk/manual/gawk.html).
+Additionally, `apt` and `iw` are required to report APT status and WiFi
+signal-strength respectively – missing these dependencies is handled gracefully.
+
+When running on embedded/minimal systems (e.g. DD-WRT, or OpenWRT), apart from
+the above dependencies, `coreutils` most likely needs to be installed. In case
+this package is further split up (like on [Entware](https://entware.net/)),
+install `coreutils-mktemp`, `coreutils-nproc`, and `coreutils-timeout`.
 
 ### Broker
 
@@ -209,6 +217,11 @@ the script's behaviour:
   discovery topic
 - `SYSMON_INTERVAL` (default: `30`) — set the interval (in seconds) at which
   metrics are reported
+  - In principle, the interval can lowered all the way down to **zero** for
+    real-time reporting (which _will_ negatively impact system performance)
+  - When `rtt-hosts` are provided, the script automatically enforces a minimum
+    reporting interval to ensure the ping-command(s) have sufficient time to
+    complete
 - `SYSMON_APT` (default: `true`) — set to `false` to disable reporting
   APT-related metrics (`apt` and `reboot_required`)
   - Automatically disabled when no `apt`-binary is present, _or_ when running

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Until December 2023, this script was part of my
 [Home Assistant configuration](https://github.com/thijsputman/home-assistant-config/tree/2ec7d637e642196f45a04fa0f99c0eeee4daba9d/extras/sysmon-mqtt)-repository.
 
 - [Version history](#version-history)
-  - [1.2.2](#122)
+  - [`edge`](#edge)
+  - [1.2.2 / `stable`](#122--stable)
   - [1.2.1](#121)
   - [1.2.0](#120)
   - [1.1.0](#110)
@@ -25,12 +26,25 @@ Until December 2023, this script was part of my
 - [Setup](#setup)
   - [Broker](#broker)
 - [Usage](#usage)
+  - [Daemon-mode](#daemon-mode)
   - [Docker](#docker)
   - [`systemd`](#systemd)
 
 ## Version history
 
-### 1.2.2
+### `edge`
+
+- Simple daemon-mode to ensure `sysmon-mqtt` keeps running
+- Support embedded/minimal Linux-systems (e.g. DD-WRT, or OpenWRT)
+  - Delay the (asynchronous) ping-commands to prevent the high load while
+    running the main loop from interfering with the round-trip times on these
+    low-powered systems
+- More elaborate device model detection; should now report something sensible on
+  most devices
+- Enforce a (dynamic) minimum length for the reporting interval to prevent
+  potentially spawning an ever increasing number of ping-commands
+
+### 1.2.2 / `stable`
 
 - Report the overall system status (systemd-only; based on the output of
   `systemctl is-system-running`)
@@ -192,9 +206,11 @@ restart)...
 From the shell:
 
 ```shell
-./sysmon.sh mqtt-broker device-name [network-adapters] [rtt-hosts]
+./sysmon.sh [--daemon] mqtt-broker device-name [network-adapters] [rtt-hosts]
 ```
 
+- `--daemon` (optional) – enable [daemon-mode](#daemon-mode); start a watchdog
+  to monitor the main `sysmon-mqtt` process
 - `mqtt-broker` — hostname or IP address of the MQTT-broker
 - `device-name` — **human-friendly** name of the device being monitored (e.g.,
   "My Raspberry Pi"); a low-fidelity version (`my_raspberry_pi`) is
@@ -215,6 +231,10 @@ the script's behaviour:
   to Home Assistant discovery topic
 - `SYSMON_HA_TOPIC` (default: `homeassistant`) — base for the Home Assistant
   discovery topic
+- `SYSMON_HA_VERSION` (default: `202308`) — specify Home Assistant version
+  compatibility (as `YYYYMM`); based on this some behaviours are modified:
+  - `>= 202308` do _not_ prepend device name to sensor name
+    ([home-assistant/core#95159](https://github.com/home-assistant/core/pull/95159))
 - `SYSMON_INTERVAL` (default: `30`) — set the interval (in seconds) at which
   metrics are reported
   - In principle, the interval can lowered all the way down to **zero** for
@@ -230,10 +250,8 @@ the script's behaviour:
   the file used to store APT-check's status
 - `SYSMON_RTT_COUNT` (default `4`) — number of ping-requests to send per
   iteration over which to average the round-trip time
-- `SYSMON_HA_VERSION` (default: `202308`) — specify Home Assistant version
-  compatibility (as `YYYYMM`); based on this some behaviours are modified:
-  - `>= 202308` do _not_ prepend device name to sensor name
-    ([home-assistant/core#95159](https://github.com/home-assistant/core/pull/95159))
+- `SYSMON_DAEMON_LOG` (default `~/sysmon-mqtt.log`) — file to redirect all
+  output to when running in [daemon-mode](#daemon-mode)
 
 Echo the `sysmon-mqtt` version and exit:
 
@@ -241,10 +259,28 @@ Echo the `sysmon-mqtt` version and exit:
 ./sysmon.sh --version
 ```
 
+### Daemon-mode
+
+As of version 1.3.0, `sysmon-mqtt` includes a simple daemon to ensure the main
+monitoring process keeps running (ie, is restarted if it terminates). This is
+primarily intended for embedded devices running minimal Linux-distributions
+lacking amenities like [Docker](#docker) or [systemd](#systemd).
+
+When started with `--daemon` as its _first_ argument, `sysmon-mqtt` will start
+in daemon-mode and fork off a child-process to do the actual work (all arguments
+after `--daemon` are passed directly to this child-process). Whenever the
+child-process exits, it will be restarted by the daemon after waiting
+`SYSMON_INTERVAL` seconds.
+
+All output is redirected to `📄 ~/sysmon-mqtt.log` – this can be controlled via
+the `SYSMON_DAEMON_LOG` environment variable.
+
+To stop the daemon, send a `SIGKILL` the _daemon_-process.
+
 ### Docker
 
-The simplest (if slightly constrained) way of running the script is via the
-Docker-container published on
+The most straightforward (if slightly constrained) way of running the script is
+via the Docker-container published on
 [Docker Hub](https://hub.docker.com/r/thijsputman/sysmon-mqtt) and
 [GHCR](https://github.com/thijsputman/home-assistant-config/pkgs/container/sysmon-mqtt).
 Container images are available for `amd64`, `arm64`, and `armhf`.
@@ -256,7 +292,7 @@ into the container (as is done in the below
 _latter_ approach (`iw` relies on the physical network adapter being accessible;
 mounting `/sys` doesn't suffice).
 
-The `/sys`-approach is preferred as it's more flexible (i.e., it can be used to
+The `/sys`-approach is preferred as it's more flexible (ie, it can be used to
 gather additional information such as the device model) and offers better
 security: The container's network remains isolated; instead it gains _read-only_
 access to `/sys` with Docker's AppArmor policies applied to prevent access to
@@ -267,7 +303,11 @@ inside the container though 😵 — see
 [moby#434199](https://github.com/moby/moby/issues/43419) for details. Until that
 issue is resolved, you'll need to run a privileged container (easiest, if
 slightly too broad, is via `privileged: true`) which is **_not_** worth the risk
-just to have the device model reported.
+just to have the proper device model reported.
+
+As of version 1.3.0, `sysmon-mqtt` falls back to a more generic device model in
+case it can't read from `/sys/firmware` (e.g., "Raspberry Pi 4 Model B Rev 1.2"
+becomes "BCM2835").
 
 If you don't care about bandwidth monitoring (and/or the device model), the
 `/sys`-mount can be removed.
@@ -288,6 +328,10 @@ services:
     # Mount host's /sys-sysfs (read-only) into the container
     volumes:
       - /sys:/sys:ro
+    # Alternatively, use host networking...
+    # network_mode: host
+    # ...or run in privileged mode (strongly discouraged)
+    # privileged: true
     environment:
       - MQTT_BROKER=
       - DEVICE_NAME=

--- a/sysmon.sh
+++ b/sysmon.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-SYSMON_MQTT_VERSION='1.2.2'
+SYSMON_MQTT_VERSION='1.3.0-dev'
 echo "sysmon-mqtt $SYSMON_MQTT_VERSION"
 
 if [ "$*" == "--version" ]; then
@@ -39,6 +39,20 @@ device_name="${2:?"Missing device name!"}"
 # Optional
 read -r -a eth_adapters <<< "${3:-}"
 read -r -a rtt_hosts <<< "${4:-}"
+
+# When round-trip times are to be reported, ensure the reporting interval is
+# longer than the maximum time required to complete all of the ping-commands.
+# This to prevent people from shooting themselves in the foot by setting the
+# interval too low and spawning an ever increasing number of ping-commands.
+
+if [ ${#rtt_hosts[@]} -gt 0 ]; then
+  minimum_interval=$(((10#$SYSMON_RTT_COUNT + 1) * ${#rtt_hosts[@]} + (\
+    10#$SYSMON_INTERVAL * 2 / 10)))
+  if [ $((10#$SYSMON_INTERVAL)) -lt $minimum_interval ]; then
+    echo " \-> Increased SYSMON_INTERVAL to $minimum_interval"
+    SYSMON_INTERVAL=$minimum_interval
+  fi
+fi
 
 # Exit-trap handler
 
@@ -219,15 +233,37 @@ ha_discover() {
       printf "%s" "$name"
     } | jq -R -s '.'
   )
+  payload_model=""
 
-  # The use of cat is intentional here (it redirects "not found"-errors to
-  # /dev/null). Furthermore, no model is reported in (non-privileged) Docker-
-  # containers while <https://github.com/moby/moby/issues/43419> remains open...
-  # shellcheck disable=SC2002
+  # Attempt to retrieve the most sensible device model description
 
-  payload_model=$(
-    cat /sys/firmware/devicetree/base/model 2> /dev/null | tr -d '\0' || true
-  )
+  # Raspberry Pi,et al.
+  if [ -f /sys/firmware/devicetree/base/model ]; then
+    payload_model=$(
+      tr -d '\0' < /sys/firmware/devicetree/base/model || true
+    )
+  fi
+
+  # DD-WRT
+  if [ -z "$payload_model" ] && command -v nvram &> /dev/null; then
+    payload_model="$(nvram get DD_BOARD)"
+  fi
+
+  # Generic SBCs & embedded systems (e.g. OpenWRT)
+  if [ -z "$payload_model" ]; then
+    payload_model=$(
+      grep -i hardware /proc/cpuinfo | cut -d ':' -f2 || true
+    )
+    payload_model="${payload_model/ /}"
+  fi
+
+  # PCs (and fallback)
+  if [ -z "$payload_model" ]; then
+    payload_model=$(
+      grep -i 'model name' /proc/cpuinfo | cut -d ':' -f2 || true
+    )
+    payload_model="${payload_model/ /}"
+  fi
 
   # Attempt to retrieve existing UUID; otherwise generate a new one
 
@@ -308,7 +344,7 @@ if [ "$SYSMON_HA_DISCOVER" = true ]; then
     ha_discover "Bandwidth out (${eth_adapter})" "bandwidth/${eth_adapter}/tx" \
       mdi:upload-network data_rate kbit/s
 
-    if [[ $eth_adapter =~ ^wl ]]; then
+    if command -v iw &> /dev/null && [[ $eth_adapter =~ ^wl ]]; then
       ha_discover "Signal strength (${eth_adapter})" \
         "bandwidth/${eth_adapter}/signal" \
         mdi:wifi-strength-3 signal_strength dBm 0
@@ -375,7 +411,7 @@ payload_rtt=""
 
 # ZFS ARC — minimum size
 if [ -f /proc/spl/kstat/zfs/arcstats ]; then
-  zfs_arc_min=$(awk '/^c_min/ {printf "%.0f", $3/1024 }' < \
+  zfs_arc_min=$(gawk '/^c_min/ {printf "%.0f", $3/1024 }' < \
     /proc/spl/kstat/zfs/arcstats)
 fi
 
@@ -386,7 +422,7 @@ while true; do
 
   # CPU temperature
   if [ -r /sys/class/thermal/thermal_zone0/temp ]; then
-    cpu_temp=$(awk '{printf "%3.2f", $0/1000 }' < \
+    cpu_temp=$(gawk '{printf "%3.2f", $0/1000 }' < \
       /sys/class/thermal/thermal_zone0/temp)
   fi
 
@@ -397,26 +433,26 @@ while true; do
 
   # Load (1-minute load / # of cores)
   cpu_load=$(uptime |
-    awk "match(\$0, /load average: ([0-9\.]*),/, \
+    gawk "match(\$0, /load average: ([0-9\.]*),/, \
       result){printf \"%3.2f\", result[1]*100/$cpu_cores}")
 
   # Memory usage (1 - total / available)
-  mem_total=$(free | awk 'NR==2{print $2}')
-  mem_avail=$(free | awk 'NR==2{print $7}')
+  mem_total=$(free | gawk 'NR==2{print $2}')
+  mem_avail=$(free | gawk 'NR==2{print $7}')
 
   # Account for ZFS ARC — this is "buff/cache", but counted as "used" by the
   # kernel in Linux. Approach taken from btop: If current ARC size is greater
   # than its minimum size (lower than which it'll never go), assume the surplus
   # to be available memory.
   if [ -v zfs_arc_min ] && [ -n "$zfs_arc_min" ]; then
-    zfs_arc_size=$(awk '/^size/ {printf "%.0f", $3/1024}' < \
+    zfs_arc_size=$(gawk '/^size/ {printf "%.0f", $3/1024}' < \
       /proc/spl/kstat/zfs/arcstats)
     if [ "$zfs_arc_size" -gt "$zfs_arc_min" ]; then
       mem_avail=$((mem_avail + zfs_arc_size - zfs_arc_min))
     fi
   fi
 
-  mem_used=$(awk \
+  mem_used=$(gawk \
     '{printf "%3.2f", (1-($1/$2))*100}' <<< "$mem_avail $mem_total")
 
   # Bandwith (in kbps; measured over the "sysmon interval")
@@ -436,16 +472,16 @@ while true; do
     if [ "${#rx_prev[@]}" -eq "${#eth_adapters[@]}" ]; then
 
       payload_rx=$(
-        awk '{printf "%3.2f", ($1-$2)/$3*8/1000}' \
+        gawk '{printf "%3.2f", ($1-$2)/$3*8/1000}' \
           <<< "$rx ${rx_prev[i]} $((10#$SYSMON_INTERVAL))"
       )
       payload_tx=$(
-        awk '{printf "%3.2f", ($1-$2)/$3*8/1000}' \
+        gawk '{printf "%3.2f", ($1-$2)/$3*8/1000}' \
           <<< "$tx ${tx_prev[i]} $((10#$SYSMON_INTERVAL))"
       )
 
       signal=''
-      if [[ $eth_adapter =~ ^wl ]]; then
+      if command -v iw &> /dev/null && [[ $eth_adapter =~ ^wl ]]; then
         signal=$(
           iw "$eth_adapter" link | grep -E 'signal: \-[[:digit:]]+ dBm' |
             grep -oE '\-[[:digit:]]+' || :
@@ -479,12 +515,21 @@ while true; do
     (
       rtt_times=()
 
+      # If the reporting interval allows it, wait a couple of seconds – on slow
+      # systems, running this right away (ie, while the "main" loop is active)
+      # has a noticeable impact on the round-trip times...
+      sleep $((10#$SYSMON_INTERVAL * 2 / 10))
+
       for i in "${!rtt_hosts[@]}"; do
 
         rtt_host="${rtt_hosts[i]}"
 
+        # In case of DNS errors, or unreachable hosts, ping can take quite a
+        # while to complete – enforce a timeout (of roughly speaking two-seconds
+        # more than needed) to ensure a predictable maximum duration.
         readarray -t result < <(
-          ping -c "$((10#$SYSMON_RTT_COUNT))" \
+          timeout $((10#$SYSMON_RTT_COUNT + 1)) \
+            ping -c "$((10#$SYSMON_RTT_COUNT))" \
             "$rtt_host" | grep 'rtt\|round-trip' |
             grep -oE '[[:digit:]]+\.[[:digit:]]{3}' || :
         )
@@ -537,12 +582,12 @@ while true; do
       # Fork it off so we don't block on waiting for this to complete
       (
         # shellcheck disable=SC1004
-        apt_simulate=$(apt --simulate upgrade 2> /dev/null | awk \
+        apt_simulate=$(apt --simulate upgrade 2> /dev/null | gawk \
           'BEGIN{RS=""} ; match($0, \
             /The following packages will be upgraded:(.* not upgraded.)/,
           result){printf "%s", result[1]}')
 
-        apt_upgrades=$(tail -n 1 <<< "$apt_simulate" | awk \
+        apt_upgrades=$(tail -n 1 <<< "$apt_simulate" | gawk \
           'match($0, /([0-9]+) upgraded,/, result){printf "%d", result[1]}')
         if [ -z "$apt_upgrades" ]; then
           apt_upgrades=0

--- a/sysmon.sh
+++ b/sysmon.sh
@@ -290,7 +290,7 @@ ha_discover() {
   # Generic SBCs & embedded systems (e.g. OpenWRT)
   if [ -z "$payload_model" ]; then
     payload_model=$(
-      grep -i hardware /proc/cpuinfo | cut -d ':' -f2 || true
+      grep -i -m 1 hardware /proc/cpuinfo | cut -d ':' -f2 || true
     )
     payload_model="${payload_model/ /}"
   fi
@@ -298,7 +298,7 @@ ha_discover() {
   # PCs (and fallback)
   if [ -z "$payload_model" ]; then
     payload_model=$(
-      grep -i 'model name' /proc/cpuinfo | cut -d ':' -f2 || true
+      grep -i -m 1 'model name' /proc/cpuinfo | cut -d ':' -f2 || true
     )
     payload_model="${payload_model/ /}"
   fi


### PR DESCRIPTION
Apart from some additional dependencies (ie, documentation changes), three changes were required:

1. Explicitly use `gawk` instead of `awk` (busybox doesn't automatically fall-through to `gawk`)
2. Expand the device model detection to include DD-WRT (and more generically from `/proc/cpuinfo`)
3. Delay the `ping`-command(s) for a couple seconds. Running them right away has a substantial (negative) impact on the round-trip times reported from my main DD-WRT unit

As some additional gold-plating, the script now also enforces a minimal reporting interval (and a maximum duration for each `ping`-command) to ensure it's not possible to spawn an ever-increasing number of `ping`-commands (and effectively DoS yourself).

## ToDo

- [x] Test the new device model detection on more devices (at least on my laptop and inside a Docker container)
- [x] Add a simple process watchdog – DD-WRT doesn't provide service management, so probably best to provide a simple watchdog that restarts the script should it crash
- [x] Check what happens when the output of `ping` is invalid
  - As intended, it'll return no output as part of the MQTT payload
- [x] Update README