### PR TITLE
More generic fan speed support

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ the script's behaviour:
     `false`...
 - `SYSMON_FAN_SPEED` (default `false`) – enable fan speed measurement(s) using
   lm-sensors' `sensors`-command
-  - Currently only supported on the [LattePanda Mu](#lattepanda-mu), expect
-    undefined behaviour when enabling this on other devices...
+  - Currently only a handful of sensor chips are supported, see the
+    [fan speed section](#fan-speed) for more details
 
 Echo the `sysmon-mqtt` version and exit:
 

--- a/README.md
+++ b/README.md
@@ -445,8 +445,8 @@ Optionally, lists of `network-adapters` and `rtt-hosts` can also be passed in:
 
 ```shell
 export SYSMON_HA_BASE=http://homeassistant.local
-sudo -E ./install.sh mqtt-broker.local "Device Name" "eth0 wlan0" \
-  "router.local 8.8.8.8"
+./install.sh  \
+  mqtt-broker.local "Device Name" "eth0 wlan0" "router.local 8.8.8.8"
 ```
 
 All environment-variables that start with `SYSMON_` have their current value
@@ -474,6 +474,6 @@ For the very brave, the script can be run from GitHub directly:
 ```shell
 export SYSMON_HA_BASE=http://homeassistant.local
 curl -fsSL https://github.com/thijsputman/sysmon-mqtt/raw/main/install.sh |
-  sudo -E bash -s - \
+  bash -s -- \
     mqtt-broker.local "Device Name" "eth0 wlan0" "8.8.8.8 google.com"
 ```

--- a/README.md
+++ b/README.md
@@ -449,6 +449,10 @@ export SYSMON_HA_BASE=http://homeassistant.local
   mqtt-broker.local "Device Name" "eth0 wlan0" "router.local 8.8.8.8"
 ```
 
+**❗N.B.** The installer will try to invoke `sudo` if/when required. If `sudo`
+is not present on the system, you'll need to manually ensure the script runs
+with root-privileges...
+
 All environment-variables that start with `SYSMON_` have their current value
 automatically included in the service-definition.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Until December 2023, this script was part of my
 [`📄 HISTORY.md`](./HISTORY.md).
 
 - [Metrics](#metrics)
+  - [Fan speed](#fan-speed)
   - [Device-specific metrics](#device-specific-metrics)
   - [Heartbeat](#heartbeat)
   - [Home Assistant discovery](#home-assistant-discovery)
@@ -36,6 +37,7 @@ Currently, the following metrics are provided:
   `/sys/class/thermal/thermal_zone*/temp` – omitted when none found)
 - `mem_used` — memory in use (_excluding_ buffers and caches) as a percentage of
   total available memory
+- `fan_speed` – Fan speed in RPM ([see below](#fan-speed) for caveats)
 - `uptime` — uptime in seconds
 - `status` – overall status of the system (systemd-only;
   [as reported by `systemctl is-system-running`](https://www.freedesktop.org/software/systemd/man/systemctl.html#is-system-running))
@@ -55,6 +57,22 @@ topic.
 
 Additionally, the version of the running `sysmon-mqtt`-script is provided in
 `sysmon/[device-name]/version`.
+
+### Fan speed
+
+The current fan speed implementation is crude: It will report the highest fan
+RPM in the output of lm-sensors' `sensors`-command for any of the supported
+chips. If multiple fans are connected (a not unrealistic assumption), the
+measurement randomly oscillates between multiple fans...
+
+The currently supported chips are:
+
+- `it8613-*` – [IT8613E-chip on DFR1142 Lite Carrier Board](#lattepanda-mu)
+- `pwmfan-*` – Amongst others, the Raspberry Pi 5's onboard fan header
+
+To enable the implementation, [`SYSMON_FAN_SPEED`](#usage) needs to be
+explicitly set to `true` (and will only remain `true` only if a supported chip
+is present).
 
 ### Device-specific metrics
 
@@ -96,20 +114,10 @@ that issue as well.
 
 #### LattePanda Mu
 
-On a [LattePanda Mu](https://www.lattepanda.com/lattepanda-mu) (specifically,
-its DFR1142 Lite Carrier Board with the IT8613E-chip), the status of the fan
-connected to the carrier board's fan-header can be reported:
-
-- `fan_speed` – Fan speed in RPM
-
-The current implementation is crude: It will report the highest fan RPM in the
-output of lm-sensors' `sensors`-command for the `it8613`-chip. If multiple fans
-are connected (non-trivial on the carrier board; most likely possible on other
-boards), the measurement randomly oscillates between multiple fans...
-
-Thus, to enable the implementation, [`SYSMON_FAN_SPEED`](#usage) needs to be
-explicitly set to `true` (and will only remain `true` if an `it8613`-chip is
-present). Furthermore, a custom kernel driver needs to be compiled:
+To report the status of the fan connected to the fan-header on a
+[LattePanda Mu](https://www.lattepanda.com/lattepanda-mu) (more specifically,
+its DFR1142 Lite Carrier Board with the IT8613E-chip), a custom kernel driver
+needs to be compiled:
 
 ```shell
 sudo apt install \

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ The currently supported chips are:
 - `pwmfan-*` – Amongst others, the Raspberry Pi 5's onboard fan header
 
 To enable the implementation, [`SYSMON_FAN_SPEED`](#usage) needs to be
-explicitly set to `true` (and will only remain `true` only if a supported chip
-is present).
+explicitly set to `true` (and will only remain `true` if a supported chip is
+present).
 
 ### Device-specific metrics
 

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,15 @@ export DEBIAN_FRONTEND=noninteractive
 install=false
 
 # Prime sudo
+if ! command -v sudo &> /dev/null; then
+  # When not available, replace with no-op
+  sudo() {
+    if [[ ${1-} == -* ]]; then
+      return 0
+    fi
+    "$@"
+  }
+fi
 sudo -v
 
 # If no service is present, always start the install-routine. Otherwise, only
@@ -61,8 +70,13 @@ else
     mosquitto-clients
 fi
 
-mkdir -p "$HOME/.local/bin"
-sysmon_target="$HOME/.local/bin/sysmon-mqtt"
+local_bin="$HOME/.local/bin"
+if ((EUID == 0)); then
+  local_bin="/usr/local/bin"
+fi
+
+mkdir -p "$local_bin"
+sysmon_target="$local_bin/sysmon-mqtt"
 
 wget -O "$sysmon_target" "$(tr -d ' ' <<< "$sysmon_url")"
 chmod +x "$sysmon_target"

--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,6 @@ mkdir -p "$HOME/.local/bin"
 sysmon_target="$HOME/.local/bin/sysmon-mqtt"
 
 wget -O "$sysmon_target" "$(tr -d ' ' <<< "$sysmon_url")"
-chown "$(whoami):" "$sysmon_target"
 chmod +x "$sysmon_target"
 
 if $install; then

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,9 @@ export DEBIAN_FRONTEND=noninteractive
 
 install=false
 
+# Prime sudo
+sudo -v
+
 # If no service is present, always start the install-routine. Otherwise, only
 # do so if at least _one_ argument is passed into this script.
 
@@ -42,15 +45,15 @@ sysmon_url="https://raw.githubusercontent.com/thijsputman/sysmon-mqtt/\
   ${SYSMON_INSTALL_COMMIT,,}/sysmon.sh"
 
 if [[ -e /etc/systemd/system/sysmon-mqtt.service ]]; then
-  systemctl stop sysmon-mqtt
+  sudo systemctl stop sysmon-mqtt
   if $install; then
-    systemctl disable sysmon-mqtt
-    rm /etc/systemd/system/sysmon-mqtt.service
+    sudo systemctl disable sysmon-mqtt
+    sudo rm /etc/systemd/system/sysmon-mqtt.service
   fi
 # Assumes dependencies are only relevant on first ever install...
 else
-  apt update
-  apt install -y \
+  sudo apt update
+  sudo apt install -y \
     bash \
     gawk \
     iw \
@@ -62,7 +65,7 @@ mkdir -p "$HOME/.local/bin"
 sysmon_target="$HOME/.local/bin/sysmon-mqtt"
 
 wget -O "$sysmon_target" "$(tr -d ' ' <<< "$sysmon_url")"
-chown "${SUDO_USER:-$(whoami)}:" "$sysmon_target"
+chown "$(whoami):" "$sysmon_target"
 chmod +x "$sysmon_target"
 
 if $install; then
@@ -81,7 +84,7 @@ if $install; then
     fi
   done < <(env)
 
-  tee /etc/systemd/system/sysmon-mqtt.service <<- EOF > /dev/null
+  sudo tee /etc/systemd/system/sysmon-mqtt.service <<- EOF > /dev/null
 		[Unit]
 		Description=Simple system monitoring over MQTT
 		After=network-online.target
@@ -105,10 +108,10 @@ if $install; then
 		[Install]
 		WantedBy=multi-user.target
 	EOF
-  # N.B. heredoc should be indented with tabs...
+  #❗N.B. heredoc should be indented with tabs...
 
-  systemctl daemon-reload
-  systemctl enable sysmon-mqtt
+  sudo systemctl daemon-reload
+  sudo systemctl enable sysmon-mqtt
 
 fi
 
@@ -117,5 +120,9 @@ if [[ ! -e /etc/systemd/system/sysmon-mqtt.service ]]; then
   exit 1
 fi
 
-systemctl start sysmon-mqtt
-exit $?
+sudo systemctl start sysmon-mqtt
+rc=$?
+
+sudo -k
+
+exit $rc

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-export DEBIAN_FRONTEND=noninteractive
-
 : "${SYSMON_INSTALL_COMMIT:=main}"
 
 install=false
@@ -61,8 +59,9 @@ if [[ -e /etc/systemd/system/sysmon-mqtt.service ]]; then
   fi
 # Assumes dependencies are only relevant on first ever install...
 else
-  sudo apt update
-  sudo apt install -y \
+  sudo DEBIAN_FRONTEND=noninteractive apt update
+  sudo DEBIAN_FRONTEND=noninteractive apt install \
+    --no-install-recommends -y \
     bash \
     gawk \
     iw \

--- a/sysmon.sh
+++ b/sysmon.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 : "${SYSMON_INSTALL_COMMIT:=main}"
-SYSMON_MQTT_VERSION='1.4.0'
+SYSMON_MQTT_VERSION='1.4.1-dev'
 
 if [[ -n $SYSMON_INSTALL_COMMIT && ${SYSMON_INSTALL_COMMIT,,} != main ]]; then
   SYSMON_MQTT_VERSION+="-${SYSMON_INSTALL_COMMIT,,}"
@@ -98,7 +98,11 @@ fi
 # supported chip is detected.
 if [[ ${SYSMON_FAN_SPEED,,} == "true" ]]; then
   SYSMON_FAN_SPEED="false"
-  if command -v sensors &> /dev/null && sensors it8613-\* &> /dev/null; then
+  sensors_fans=(it8613-\* pwmfan-\*)
+  if
+    command -v sensors &> /dev/null &&
+      sensors "${sensors_fans[@]}" &> /dev/null
+  then
     SYSMON_FAN_SPEED="true"
   fi
 fi
@@ -575,8 +579,8 @@ while true; do
     command -v sensors &> /dev/null; then
     # shellcheck disable=SC2034 # Indirect reference only
     fan_speed=$(
-      sensors it8613-\* 2> /dev/null |
-        gawk '/fan[0-9]+/ {if ($2+0 > max) max = $2} END {print max}' || true
+      sensors "${sensors_fans[@]}" 2> /dev/null |
+        gawk '/fan[0-9]+/ {if ($2+0 >= max) max = $2+0} END {print max}' || true
     )
   fi
 


### PR DESCRIPTION
Still crude, but more expandable towards the future. Now works for the Raspberry Pi 5's onboard fan-header.

Also, update the install script to not require `sudo -E` anymore (doesn't work in sudo-rs; calling `sudo` on-demand in the script was more elegant to begin with).